### PR TITLE
[FIX] purchase_discount: Fix undefined argument on purchase_discount: original function use move=False and inherited function just use move

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -104,7 +104,7 @@ class PurchaseOrderLine(models.Model):
             return
         self.discount = seller.discount
 
-    def _prepare_account_move_line(self, move):
+    def _prepare_account_move_line(self, move=False):
         vals = super(PurchaseOrderLine, self)._prepare_account_move_line(move)
         vals["discount"] = self.discount
         return vals


### PR DESCRIPTION
The original code, with no stock_landed_costs installed, caused the following error https://gist.github.com/rolandojduartem/64f4c0775d1eb11ff9c6bcfda02b94be at the moment to create an invoice from a purchase order. This code fix that error. The original function is https://github.com/odoo/odoo/blob/14.0/addons/purchase/models/purchase.py#L1143

![purchase-wokflow_fix](https://user-images.githubusercontent.com/90422721/154147798-ffd7c76a-6561-4e7c-8870-dbb3d016e3dd.png)
