### PR TITLE
[IMP] purchase_advance_payment: Add attachments button in tree view of payments

### DIFF
--- a/purchase_advance_payment/__manifest__.py
+++ b/purchase_advance_payment/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Purchase Advance Payment",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "author": "Forgeflow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchase",
@@ -14,6 +14,7 @@
         "security/groups.xml",
         "wizard/purchase_advance_payment_wizard_view.xml",
         "views/purchase_view.xml",
+        "views/account_payment_view.xml",
         "security/ir.model.access.csv",
         "security/ir_rules.xml",
     ],

--- a/purchase_advance_payment/models/__init__.py
+++ b/purchase_advance_payment/models/__init__.py
@@ -1,1 +1,2 @@
 from . import purchase_order
+from . import account_payment

--- a/purchase_advance_payment/models/account_payment.py
+++ b/purchase_advance_payment/models/account_payment.py
@@ -7,6 +7,12 @@ class AccountPayment(models.Model):
     def action_get_attachment_view(self):
         self.ensure_one()
         res = self.env["ir.actions.act_window"]._for_xml_id("base.action_attachment")
-        res["domain"] = [("res_model", "=", "account.payment"), ("res_id", "in", self.ids)]
-        res["context"] = {"default_res_model": "account.payment", "default_res_id": self.id}
+        res["domain"] = [
+            ("res_model", "=", "account.payment"),
+            ("res_id", "in", self.ids),
+        ]
+        res["context"] = {
+            "default_res_model": "account.payment",
+            "default_res_id": self.id,
+        }
         return res

--- a/purchase_advance_payment/models/account_payment.py
+++ b/purchase_advance_payment/models/account_payment.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    def action_get_attachment_view(self):
+        self.ensure_one()
+        res = self.env["ir.actions.act_window"]._for_xml_id("base.action_attachment")
+        res["domain"] = [("res_model", "=", "account.payment"), ("res_id", "in", self.ids)]
+        res["context"] = {"default_res_model": "account.payment", "default_res_id": self.id}
+        return res

--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -9,9 +9,7 @@ class PurchaseOrder(models.Model):
 
     _inherit = "purchase.order"
 
-    account_payment_ids = fields.Many2many(
-        "account.payment", string="Pay purchase advanced", readonly=True
-    )
+    account_payment_ids = fields.Many2many("account.payment", string="Pay purchase advanced", readonly=True)
     amount_residual = fields.Float(
         "Residual amount",
         readonly=True,
@@ -36,9 +34,7 @@ class PurchaseOrder(models.Model):
         tracking=True,
         compute="_compute_purchase_advance_payment",
     )
-    payments_date = fields.Char(
-        help="All dates of payments related to this order", compute="_compute_payments_date"
-    )
+    payments_date = fields.Char(help="All dates of payments related to this order", compute="_compute_payments_date")
 
     @api.depends(
         "currency_id",
@@ -89,10 +85,8 @@ class PurchaseOrder(models.Model):
                 invoice_paid_amount += inv.amount_total - inv.amount_residual
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
-            if mls or order.invoice_ids:
-                has_due_amount = float_compare(
-                    amount_residual, 0.0, precision_rounding=order.currency_id.rounding
-                )
+            if (mls or order.invoice_ids) and order.account_payment_ids:
+                has_due_amount = float_compare(amount_residual, 0.0, precision_rounding=order.currency_id.rounding)
                 if has_due_amount <= 0:
                     payment_state = "paid"
                 elif has_due_amount > 0:

--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -9,7 +9,9 @@ class PurchaseOrder(models.Model):
 
     _inherit = "purchase.order"
 
-    account_payment_ids = fields.Many2many("account.payment", string="Pay purchase advanced", readonly=True)
+    account_payment_ids = fields.Many2many(
+        "account.payment", string="Pay purchase advanced", readonly=True
+    )
     amount_residual = fields.Float(
         "Residual amount",
         readonly=True,
@@ -34,7 +36,10 @@ class PurchaseOrder(models.Model):
         tracking=True,
         compute="_compute_purchase_advance_payment",
     )
-    payments_date = fields.Char(help="All dates of payments related to this order", compute="_compute_payments_date")
+    payments_date = fields.Char(
+        help="All dates of payments related to this order",
+        compute="_compute_payments_date",
+    )
 
     @api.depends(
         "currency_id",
@@ -86,7 +91,9 @@ class PurchaseOrder(models.Model):
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
             if (mls or order.invoice_ids) and order.account_payment_ids:
-                has_due_amount = float_compare(amount_residual, 0.0, precision_rounding=order.currency_id.rounding)
+                has_due_amount = float_compare(
+                    amount_residual, 0.0, precision_rounding=order.currency_id.rounding
+                )
                 if has_due_amount <= 0:
                     payment_state = "paid"
                 elif has_due_amount > 0:
@@ -98,5 +105,8 @@ class PurchaseOrder(models.Model):
     def _compute_payments_date(self):
         for record in self:
             record.payments_date = ", ".join(
-                {date.strftime("%d-%m-%Y") for date in record.account_payment_ids.mapped("date")}
+                {
+                    date.strftime("%d-%m-%Y")
+                    for date in record.account_payment_ids.mapped("date")
+                }
             )

--- a/purchase_advance_payment/security/groups.xml
+++ b/purchase_advance_payment/security/groups.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
-    <record id="purchase_advance_payment.group_purchase_payments" model="res.groups">
+    <record id="group_purchase_payments" model="res.groups">
         <field name="name">Allows you to view payments in Purchases</field>
         <field name="implied_ids" eval="[(4, ref('purchase.group_purchase_user'))]" />
         <field name="category_id" ref="base.module_category_inventory_purchase" />

--- a/purchase_advance_payment/views/account_payment_view.xml
+++ b/purchase_advance_payment/views/account_payment_view.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data>
+        <record id="view_account_payment_tree_inherit" model="ir.ui.view">
+            <field name="name">account.payment.tree.inherit</field>
+            <field name="model">account.payment</field>
+            <field name="inherit_id" ref="account.view_account_payment_tree" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='partner_id']" position="before">
+                    <button name="action_get_attachment_view" string="Attachments" type="object" icon="fa-paperclip" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/purchase_advance_payment/views/account_payment_view.xml
+++ b/purchase_advance_payment/views/account_payment_view.xml
@@ -1,14 +1,17 @@
 <odoo>
-    <data>
-        <record id="view_account_payment_tree_inherit" model="ir.ui.view">
-            <field name="name">account.payment.tree.inherit</field>
-            <field name="model">account.payment</field>
-            <field name="inherit_id" ref="account.view_account_payment_tree" />
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='partner_id']" position="before">
-                    <button name="action_get_attachment_view" string="Attachments" type="object" icon="fa-paperclip" />
-                </xpath>
-            </field>
-        </record>
-    </data>
+    <record id="view_account_payment_tree_inherit" model="ir.ui.view">
+        <field name="name">account.payment.tree.inherit</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="before">
+                <button
+                    name="action_get_attachment_view"
+                    string="Attachments"
+                    type="object"
+                    icon="fa-paperclip"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/purchase_advance_payment/views/purchase_view.xml
+++ b/purchase_advance_payment/views/purchase_view.xml
@@ -15,7 +15,10 @@
                 />
             </button>
             <notebook position="inside">
-                <page string="Payment advances" groups="purchase_advance_payment.group_purchase_payments, purchase.group_purchase_manager">
+                <page
+                    string="Payment advances"
+                    groups="purchase_advance_payment.group_purchase_payments, purchase.group_purchase_manager"
+                >
                     <field
                         name="account_payment_ids"
                         nolabel="1"

--- a/purchase_advance_payment/wizard/account_payment_register.py
+++ b/purchase_advance_payment/wizard/account_payment_register.py
@@ -8,9 +8,14 @@ class AccountPaymentRegister(models.TransientModel):
         """Inherited method to relate payments automatically when generate payments from an account.move"""
         payments = super()._create_payments()
         active_ids = self.env.context.get("active_ids", [])
-        if self.env.context.get("active_model") == "account.move" and len(active_ids) > 0:
+        if (
+            self.env.context.get("active_model") == "account.move"
+            and len(active_ids) > 0
+        ):
             for move in self.env["account.move"].browse(active_ids).exists():
-                orders = self.env["purchase.order"].search([("invoice_ids", "in", move.ids)])
+                orders = self.env["purchase.order"].search(
+                    [("invoice_ids", "in", move.ids)]
+                )
                 orders.account_payment_ids |= payments.filtered(
                     lambda p: move in (p.reconciled_bill_ids | p.reconciled_invoice_ids)
                 )

--- a/purchase_advance_payment/wizard/account_payment_register.py
+++ b/purchase_advance_payment/wizard/account_payment_register.py
@@ -1,4 +1,4 @@
-from odoo import Command, models
+from odoo import models
 
 
 class AccountPaymentRegister(models.TransientModel):
@@ -7,9 +7,11 @@ class AccountPaymentRegister(models.TransientModel):
     def _create_payments(self):
         """Inherited method to relate payments automatically when generate payments from an account.move"""
         payments = super()._create_payments()
-        ctx = self._context
-        if ctx.get("active_model") == "account.move" and len(ctx.get("active_ids", [])) <= 1:
-            move = self.env["account.move"].browse(ctx.get("active_id", [])).exists()
-            orders = self.env["purchase.order"].search([("invoice_ids", "in", move.ids)])
-            orders.write({"account_payment_ids": [Command.link(id) for id in payments.ids]})
+        active_ids = self.env.context.get("active_ids", [])
+        if self.env.context.get("active_model") == "account.move" and len(active_ids) > 0:
+            for move in self.env["account.move"].browse(active_ids).exists():
+                orders = self.env["purchase.order"].search([("invoice_ids", "in", move.ids)])
+                orders.account_payment_ids |= payments.filtered(
+                    lambda p: move in (p.reconciled_bill_ids | p.reconciled_invoice_ids)
+                )
         return payments

--- a/purchase_advance_payment/wizard/account_payment_register.py
+++ b/purchase_advance_payment/wizard/account_payment_register.py
@@ -5,7 +5,9 @@ class AccountPaymentRegister(models.TransientModel):
     _inherit = "account.payment.register"
 
     def _create_payments(self):
-        """Inherited method to relate payments automatically when generate payments from an account.move"""
+        """Inherited method to relate payments automatically when
+        generate payments from an account.move
+        """
         payments = super()._create_payments()
         active_ids = self.env.context.get("active_ids", [])
         if (


### PR DESCRIPTION
Task: https://www.vauxoo.com/web#action=464&active_id=200&cids=1&id=71294&menu_id=1490&model=project.task&view_type=form

PR Related: https://github.com/Vauxoo/lavop/pull/79

Instance: https://www.odoo.sh/project/lavop/branches/15.0-lavop-imp-atts-emilioserna

Improvements:

- Fix where payments weren't relating to the purchase orders when registering payments to multiple moves.
- Fix where the payment status for the order was changing to "partially paid" even though it didn't have any payments yet.
- Improvement to add an attachment button to the tree view in payments.

![image](https://github.com/Vauxoo/purchase-workflow/assets/50151743/401eb76b-8096-4c81-b403-2a8e3abd3d8c)
![image](https://github.com/Vauxoo/purchase-workflow/assets/50151743/1dd64d82-a3ab-49c4-a665-2ac308ddabf2)
