### PR TITLE
[19.0][FIX] purchase_order_approved: keep confirmed order lines editable

### DIFF
--- a/purchase_order_approved/__manifest__.py
+++ b/purchase_order_approved/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Purchase Order Approved",
     "summary": "Add a new state 'Approved' in purchase orders.",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "category": "Purchases",
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "ForgeFlow, ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/purchase_order_approved/views/purchase_order_view.xml
+++ b/purchase_order_approved/views/purchase_order_view.xml
@@ -28,7 +28,7 @@
             <field name="order_line" position="attributes">
                 <attribute
                     name="readonly"
-                >state in ['purchase', 'done', 'cancel', 'approved']</attribute>
+                >state in ['done', 'cancel', 'approved']</attribute>
             </field>
             <field name="origin" position="attributes">
                 <attribute


### PR DESCRIPTION
## Description

`purchase_order_approved` overrides the `order_line` read-only condition and
includes the `purchase` state, so a **confirmed** purchase order no longer
allows editing its lines (received quantity, unit price, taxes, etc.). Because
this attribute fully replaces the core condition, the core `locked` flag no
longer participates, so unlocking the order does not help either.

The `purchase` state was added to the read-only list during the 17.0 migration
(`895e98d456`) and carried over to 19.0. In 16.0 the lines were locked only on
`done`, `cancel` and `approved`, leaving confirmed orders editable.

## Steps to reproduce

1. Install `purchase_order_approved`.
2. Create and confirm a purchase order.
3. Try to edit the quantity or unit price of a line → the fields are read-only.

## Fix

Drop `purchase` from the `order_line` read-only condition, restoring
`state in ['done', 'cancel', 'approved']` (the 16.0 behavior). Confirmed orders
allow editing their lines again; `done`, `cancel` and `approved` stay locked.

## Notes

The same regression is present in the 17.0 and 18.0 branches and should be
forward/back-ported.
